### PR TITLE
Fix log warnings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ if ie == nil and (debug.getupvalue == nil and debug.getlocal == nil) then
 Libox needs to be a trusted mod for weighing of coroutine sandboxes to work properly.
 If it isn't, coroutine sandboxes could fill up your server's memory with local variables and upvalues.
 
-Libox can re-use debug.getlocal and debug.getupvalue if it is already avaliable in the environment
+Libox can re-use debug.getlocal and debug.getupvalue if it is already available in the environment
 When adding libox to secure.trusted_mods, be aware that it will expose debug.getlocal and debug.getupvalue
 ================================================
 ]]
@@ -26,7 +26,7 @@ if ie and jit then
 	else -- Linux/Unix-like
 		lib = MP .. "/autohook/libautohook.so"
 	end
-	-- Use package.loadlib() instad of require() to prevent using
+	-- Use package.loadlib() instead of require() to prevent using
 	-- system/other apps' libraries with the same name
 	local load_func = ie.package.loadlib(lib, "luaopen_autohook")
 	if load_func then

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 ---@diagnostic disable: lowercase-global
 ---@diagnostic disable: undefined-global
+libox_autohook_module = rawget(_G, "libox_autohook_module") or nil
 local ie = core.request_insecure_environment()
-libox_autohook_module = nil
 if ie == nil and (debug.getupvalue == nil and debug.getlocal == nil) then
 	core.log(
 		"warning",

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,7 @@
-local ie = minetest.request_insecure_environment()
+---@diagnostic disable: lowercase-global
+---@diagnostic disable: undefined-global
+local ie = core.request_insecure_environment()
+libox_autohook_module = nil
 if ie == nil and (debug.getupvalue == nil and debug.getlocal == nil) then
 	core.log(
 		"warning",

--- a/init.lua
+++ b/init.lua
@@ -6,14 +6,13 @@ if ie == nil and (debug.getupvalue == nil and debug.getlocal == nil) then
 	core.log(
 		"warning",
 		[[
+
 ====Hello, this message is for server owners====
 Libox needs to be a trusted mod for weighing of coroutine sandboxes to work properly.
 If it isn't, coroutine sandboxes could fill up your server's memory with local variables and upvalues.
-
 Libox can re-use debug.getlocal and debug.getupvalue if it is already available in the environment
 When adding libox to secure.trusted_mods, be aware that it will expose debug.getlocal and debug.getupvalue
-================================================
-]]
+================================================]]
 	)
 elseif debug.getlocal == nil or debug.getupvalue == nil and ie ~= nil then
 	-- luacheck:ignore

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 local ie = minetest.request_insecure_environment()
 if ie == nil and (debug.getupvalue == nil and debug.getlocal == nil) then
-	minetest.log(
+	core.log(
 		"warning",
 		[[
 ====Hello, this message is for server owners====
@@ -83,7 +83,7 @@ else
 	core.log("info", "[libox] Autohook feature NOT available")
 end
 
-local MP = minetest.get_modpath(minetest.get_current_modname())
+local MP = core.get_modpath(core.get_current_modname())
 dofile(MP .. "/main.lua")
 
 -- Files that are executed sync only, coroutine.lua and *.test.lua
@@ -92,7 +92,7 @@ dofile(MP .. "/coroutine.lua")
 libox_autohook_module = nil
 
 -- async files
-minetest.register_async_dofile(MP .. "/main.lua")
+core.register_async_dofile(MP .. "/main.lua")
 
 local test = MP .. "/test"
 dofile(test .. "/basic_testing.lua")

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,4 @@
+libox_autohook_module = rawget(_G, "libox_autohook_module") or nil
 libox = {
     safe = {},
     supply_additional_environment = function(...) return ... end, -- for other mods to do their stuff


### PR DESCRIPTION
This PR changes this:
```plaintext
2026-03-27 18:28:45: WARNING[ServerStart]: ====Hello, this message is for server owners====
Libox needs to be a trusted mod for weighing of coroutine sandboxes to work properly.
If it isn't, coroutine sandboxes could fill up your server's memory with local variables and upvalues.

Libox can re-use debug.getlocal and debug.getupvalue if it is already avaliable in the environment
When adding libox to secure.trusted_mods, be aware that it will expose debug.getlocal and debug.getupvalue
================================================

2026-03-27 18:28:45: WARNING[ServerStart]: Undeclared global variable "libox_autohook_module" accessed at ...ts\GitHub\luanti\games\skyblock_zero\mods\libox/main.lua:10
2026-03-27 18:28:45: WARNING[ServerStart]: Undeclared global variable "libox_autohook_module" accessed at ...tHub\luanti\games\skyblock_zero\mods\libox/coroutine.lua:43
2026-03-27 18:28:45: ACTION[ServerStart]: hb.register_hudbar: stamina
```

to this:
```plaintext
2026-03-27 18:57:25: WARNING[ServerStart]: 
====Hello, this message is for server owners====
Libox needs to be a trusted mod for weighing of coroutine sandboxes to work properly.
If it isn't, coroutine sandboxes could fill up your server's memory with local variables and upvalues.
Libox can re-use debug.getlocal and debug.getupvalue if it is already available in the environment
When adding libox to secure.trusted_mods, be aware that it will expose debug.getlocal and debug.getupvalue
================================================
2026-03-27 18:57:25: ACTION[ServerStart]: hb.register_hudbar: stamina
```

as well as making minor improvements to libox's init.lua.